### PR TITLE
proposed fix for assert failure in dyn backprop

### DIFF
--- a/pydreamer/models/a2c.py
+++ b/pydreamer/models/a2c.py
@@ -120,6 +120,7 @@ class ActorCritic(nn.Module):
         if self.actor_grad == 'reinforce':
             action_logprob = policy_distr.log_prob(actions)
             loss_policy = - action_logprob * advantage_gae.detach()
+            assert (loss_policy.requires_grad and policy_entropy.requires_grad) or not loss_critic.requires_grad
         elif self.actor_grad == 'dynamics':
             loss_policy = - value_target
         else:
@@ -128,7 +129,6 @@ class ActorCritic(nn.Module):
         policy_entropy = policy_distr.entropy()
         loss_actor = loss_policy - self.entropy_weight * policy_entropy
         loss_actor = (loss_actor * reality_weight).mean()
-        assert (loss_policy.requires_grad and policy_entropy.requires_grad) or not loss_critic.requires_grad
 
         with torch.no_grad():
             metrics = dict(loss_critic=loss_critic.detach(),

--- a/pydreamer/models/a2c.py
+++ b/pydreamer/models/a2c.py
@@ -117,6 +117,7 @@ class ActorCritic(nn.Module):
         # Actor loss
 
         policy_distr = self.forward_actor(features[:-1])  # TODO: we could reuse this from dream()
+        policy_entropy = policy_distr.entropy()
         if self.actor_grad == 'reinforce':
             action_logprob = policy_distr.log_prob(actions)
             loss_policy = - action_logprob * advantage_gae.detach()
@@ -126,7 +127,6 @@ class ActorCritic(nn.Module):
         else:
             assert False, self.actor_grad
 
-        policy_entropy = policy_distr.entropy()
         loss_actor = loss_policy - self.entropy_weight * policy_entropy
         loss_actor = (loss_actor * reality_weight).mean()
 


### PR DESCRIPTION
The assert seems to be hard-coded for the case when self.actor_grad == reinforce. (P || !C): if gradients flow from the critic loss, then actor params must be updated using grads from both policy losses. This doesn't support the case when self.actor_grad == dynamics, where gradients flow from the dynamics estimate.